### PR TITLE
Make sure offhand axes also trigger the selection visualisation

### DIFF
--- a/src/main/java/com/rojel/wesv/WorldEditSelectionVisualizer.java
+++ b/src/main/java/com/rojel/wesv/WorldEditSelectionVisualizer.java
@@ -75,8 +75,7 @@ public class WorldEditSelectionVisualizer extends JavaPlugin {
                     if (itemTypeId.equals(wandItemField.get(WorldEdit.getInstance().getConfiguration()))) {
                         return true;
                     }
-                    HandSide offhand = (HandSide)HandSide.class.getDeclaredField("OFF_HAND").get(null);
-                    final String secondItemTypeId = BukkitAdapter.adapt(player).getItemInHand(offhand).getType().getId();
+                    final String secondItemTypeId = BukkitAdapter.adapt(player).getItemInHand(HandSide.OFF_HAND).getType().getId();
                     return secondItemTypeId.equals(wandItemField.get(WorldEdit.getInstance().getConfiguration()));
                 }
             } catch (ReflectiveOperationException e) {

--- a/src/main/java/com/rojel/wesv/WorldEditSelectionVisualizer.java
+++ b/src/main/java/com/rojel/wesv/WorldEditSelectionVisualizer.java
@@ -72,7 +72,12 @@ public class WorldEditSelectionVisualizer extends JavaPlugin {
                     return item.getType().getId() == wandItemField.getInt(WorldEdit.getInstance().getConfiguration());
                 } else if (wandItemField.getType() == String.class) {
                     final String itemTypeId = BukkitAdapter.adapt(player).getItemInHand(HandSide.MAIN_HAND).getType().getId();
-                    return itemTypeId.equals(wandItemField.get(WorldEdit.getInstance().getConfiguration()));
+                    if (itemTypeId.equals(wandItemField.get(WorldEdit.getInstance().getConfiguration()))) {
+                        return true;
+                    }
+                    HandSide offhand = (HandSide)HandSide.class.getDeclaredField("OFF_HAND").get(null);
+                    final String secondItemTypeId = BukkitAdapter.adapt(player).getItemInHand(offhand).getType().getId();
+                    return secondItemTypeId.equals(wandItemField.get(WorldEdit.getInstance().getConfiguration()));
                 }
             } catch (ReflectiveOperationException e) {
                 getLogger().log(Level.WARNING, "An error occured on isSelectionItem", e);


### PR DESCRIPTION
At the moment, the visualization in the axe holding mode is only when the axe is inside the main hand.

This PR changes this so it also works when the axe is inside the off-hand, in an 1.8 compatible way.

This is useful if you generally don't use the overlay, but want a quick way to toggle it, without holding the axe in your hand, I find changing whenever I have an axe in my hand more natural than that repeatedly executing a command to view the selection