### PR TITLE
Add support for VisualizationToggleEvent.

### DIFF
--- a/plugin/src/main/java/com/rojel/wesv/StorageManager.java
+++ b/plugin/src/main/java/com/rojel/wesv/StorageManager.java
@@ -49,7 +49,7 @@ public class StorageManager {
             disabledPlayers.add(p.getUniqueId());
         }
 
-        plugin.getServer().getPluginManager().callEvent(new WorldEditSelectionToggleEvent(p, enable));
+        plugin.getServer().getPluginManager().callEvent(new VisualizationToggleEvent(p, enable));
         save();
     }
 

--- a/plugin/src/main/java/com/rojel/wesv/StorageManager.java
+++ b/plugin/src/main/java/com/rojel/wesv/StorageManager.java
@@ -49,6 +49,7 @@ public class StorageManager {
             disabledPlayers.add(p.getUniqueId());
         }
 
+        plugin.getServer().getPluginManager().callEvent(new WorldEditSelectionToggleEvent(p, enable));
         save();
     }
 

--- a/plugin/src/main/java/com/rojel/wesv/VisualizationToggleEvent.java
+++ b/plugin/src/main/java/com/rojel/wesv/VisualizationToggleEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class WorldEditSelectionToggleEvent extends Event {
+public class VisualizationToggleEvent extends Event {
 
     /**
      * A list of all handlers that listen for this event.
@@ -20,18 +20,18 @@ public class WorldEditSelectionToggleEvent extends Event {
      * A state representing whether or not a player has enabled
      * or disable their WorldEdit selection visualization.
      */
-    private final boolean toggle;
+    private final boolean isEnabled;
 
     /**
-     * Constructor. Creates a new custom "WorldEditSelectionToggleEvent" event.
+     * Constructor. Creates a new custom "VisualizationToggleEvent" event.
      * 
      * @param player The player who has toggled their WorldEdit selection visualization.
-     * @param toggle The state representing whether or not the player has enabled
-     *               or disable their WorldEdit selection visualization.
+     * @param isEnabled The state representing whether or not the player has enabled
+     *                  or disable their WorldEdit selection visualization.
      */
-    public WorldEditSelectionToggleEvent(Player player, boolean toggle) {
+    public VisualizationToggleEvent(Player player, boolean isEnabled) {
         this.player = player;
-        this.toggle = toggle;
+        this.isEnabled = isEnabled;
     }
 
     /**
@@ -68,7 +68,7 @@ public class WorldEditSelectionToggleEvent extends Event {
      * 
      * @return Returns true if a player has enabled visualizations, or false if disabled. 
      */
-    public boolean getToggleState() {
-        return toggle;
+    public boolean isEnabled() {
+        return isEnabled;
     }
 }

--- a/plugin/src/main/java/com/rojel/wesv/WorldEditSelectionToggleEvent.java
+++ b/plugin/src/main/java/com/rojel/wesv/WorldEditSelectionToggleEvent.java
@@ -1,0 +1,74 @@
+package com.rojel.wesv;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class WorldEditSelectionToggleEvent extends Event {
+
+    /**
+     * A list of all handlers that listen for this event.
+     */
+    private static final HandlerList handlers = new HandlerList();
+
+    /**
+     * A player who has toggled their WorldEdit selection visualization.
+     */
+    private final Player player;
+
+    /**
+     * A state representing whether or not a player has enabled
+     * or disable their WorldEdit selection visualization.
+     */
+    private final boolean toggle;
+
+    /**
+     * Constructor. Creates a new custom "WorldEditSelectionToggleEvent" event.
+     * 
+     * @param player The player who has toggled their WorldEdit selection visualization.
+     * @param toggle The state representing whether or not the player has enabled
+     *               or disable their WorldEdit selection visualization.
+     */
+    public WorldEditSelectionToggleEvent(Player player, boolean toggle) {
+        this.player = player;
+        this.toggle = toggle;
+    }
+
+    /**
+     * Gets a list of handlers for this event.
+     *
+     * @return Returns list of handlers which listen to this event.
+     */
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    /**
+     * Gets a list of handlers for this event.
+     *
+     * @return Returns list of handlers which listen to this event.
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * Gets a player who has toggled their WorldEdit selection visualization.
+     *
+     * @return Returns player who has toggled their WorldEdit selection visualization.
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Gets a state representing whether or not a player has enabled
+     * or disable their WorldEdit selection visualization.
+     * 
+     * @return Returns true if a player has enabled visualizations, or false if disabled. 
+     */
+    public boolean getToggleState() {
+        return toggle;
+    }
+}


### PR DESCRIPTION
This adds a simple event for when players enable or disable visualizations. I needed a mechanism to check when players toggle this for a custom feature I was implementing elsewhere, and I thought it would be a useful addition for others as well.