### PR TITLE
add ability to visualize selection positions

### DIFF
--- a/compatibility/commons/src/main/java/fr/mrmicky/worldeditselectionvisualizer/compat/RegionAdapter.java
+++ b/compatibility/commons/src/main/java/fr/mrmicky/worldeditselectionvisualizer/compat/RegionAdapter.java
@@ -1,5 +1,6 @@
 package fr.mrmicky.worldeditselectionvisualizer.compat;
 
+import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionOperationException;
@@ -17,11 +18,17 @@ public interface RegionAdapter {
     @NotNull
     Vector3d getMaximumPoint();
 
+    Vector3d getPos1();
+    Vector3d getPos2();
+
     @NotNull
     Vector3d getCenter();
 
     @NotNull
     List<Vector3d> getPolygonalPoints();
+
+    @NotNull
+    List<Vector3d> getPolyhedralVertices();
 
     @NotNull
     Vector3d getEllipsoidRadius();

--- a/compatibility/commons/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/RegionInfos.java
+++ b/compatibility/commons/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/RegionInfos.java
@@ -27,10 +27,17 @@ public class RegionInfos {
         minimum = regionAdapter.getMinimumPoint();
         maximum = regionAdapter.getMinimumPoint();
 
-        width = region.getWidth();
-        length = region.getLength();
-        height = region.getHeight();
-        area = region.getArea();
+        if (minimum == Vector3d.ZERO || maximum == Vector3d.ZERO) {
+            width = 0;
+            length = 0;
+            height = 0;
+            area = 0;
+        } else {
+            width = region.getWidth();
+            length = region.getLength();
+            height = region.getHeight();
+            area = region.getArea();
+        }
         points = region instanceof ConvexPolyhedralRegion ? ((ConvexPolyhedralRegion) region).getTriangles().size() : 0;
     }
 

--- a/compatibility/v6/src/main/java/fr/mrmicky/worldeditselectionvisualizer/compat/v6/RegionAdapter6.java
+++ b/compatibility/v6/src/main/java/fr/mrmicky/worldeditselectionvisualizer/compat/v6/RegionAdapter6.java
@@ -1,5 +1,6 @@
 package fr.mrmicky.worldeditselectionvisualizer.compat.v6;
 
+import com.boydti.fawe.object.regions.PolyhedralRegion;
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.regions.ConvexPolyhedralRegion;
@@ -42,6 +43,31 @@ public class RegionAdapter6 implements RegionAdapter {
 
     @NotNull
     @Override
+    public Vector3d getPos1() {
+        if (region instanceof CuboidRegion)
+            return convPos(((CuboidRegion) region).getPos1());
+        throw new UnsupportedOperationException();
+    }
+
+    @NotNull
+    @Override
+    public Vector3d getPos2() {
+        if (region instanceof CuboidRegion)
+            return convPos(((CuboidRegion) region).getPos2());
+        throw new UnsupportedOperationException();
+    }
+
+    private Vector3d convPos(Vector pos) {
+        if (pos.getX() == 0 && pos.getY() == 0 && pos.getZ() == 0)
+            // This isn't ideal, as Vector3d.ZERO is a specific instance of Vector3d which denotes an uninitialized value.
+            // WEv7 uses BlockVector3.ZERO for this purpose, while v6 does not. So in v6, we're accepting the low risk
+            // possibility that someone actually did select 0,0,0 to be able to use ==.ZERO for uninitialized position.
+            return Vector3d.ZERO;
+        return Vectors6.toVector3d(pos);
+    }
+
+    @NotNull
+    @Override
     public Vector3d getCenter() {
         return Vectors6.toVector3d(region.getCenter());
     }
@@ -54,6 +80,19 @@ public class RegionAdapter6 implements RegionAdapter {
 
             return polygonalRegion.getPoints().stream()
                     .map(vec -> new Vector3d(vec.getX(), 0, vec.getZ()))
+                    .collect(Collectors.toList());
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    @NotNull
+    @Override
+    public List<Vector3d> getPolyhedralVertices() {
+        if (region instanceof PolyhedralRegion) {
+            PolyhedralRegion polyhedralRegion = (PolyhedralRegion) region;
+
+            return polyhedralRegion.getVertices().stream()
+                    .map(vec -> new Vector3d(vec.getX(), vec.getY(), vec.getZ()))
                     .collect(Collectors.toList());
         }
         throw new UnsupportedOperationException();

--- a/compatibility/v7/src/main/java/fr/mrmicky/worldeditselectionvisualizer/compat/v7/RegionAdapter7.java
+++ b/compatibility/v7/src/main/java/fr/mrmicky/worldeditselectionvisualizer/compat/v7/RegionAdapter7.java
@@ -32,13 +32,35 @@ public class RegionAdapter7 implements RegionAdapter {
     @NotNull
     @Override
     public Vector3d getMinimumPoint() {
-        return Vectors7.toVector3d(region.getMinimumPoint());
+        BlockVector3 point = region.getMinimumPoint();
+        if (point == null)
+            return Vector3d.ZERO;
+        return Vectors7.toVector3d(point);
     }
 
     @NotNull
     @Override
     public Vector3d getMaximumPoint() {
-        return Vectors7.toVector3d(region.getMaximumPoint());
+        BlockVector3 point = region.getMaximumPoint();
+        if (point == null)
+            return Vector3d.ZERO;
+        return Vectors7.toVector3d(point);
+    }
+
+    @NotNull
+    @Override
+    public Vector3d getPos1() {
+        if (region instanceof CuboidRegion)
+            return Vectors7.toVector3d(((CuboidRegion) region).getPos1());
+        throw new UnsupportedOperationException();
+    }
+
+    @NotNull
+    @Override
+    public Vector3d getPos2() {
+        if (region instanceof CuboidRegion)
+            return Vectors7.toVector3d(((CuboidRegion) region).getPos2());
+        throw new UnsupportedOperationException();
     }
 
     @NotNull
@@ -55,6 +77,19 @@ public class RegionAdapter7 implements RegionAdapter {
 
             return polygonalRegion.getPoints().stream()
                     .map(vec -> new Vector3d(vec.getX(), 0, vec.getZ()))
+                    .collect(Collectors.toList());
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    @NotNull
+    @Override
+    public List<Vector3d> getPolyhedralVertices() {
+        if (region instanceof ConvexPolyhedralRegion) {
+            ConvexPolyhedralRegion polyhedralRegion = (ConvexPolyhedralRegion) region;
+
+            return polyhedralRegion.getVertices().stream()
+                    .map(vec -> new Vector3d(vec.getX(), vec.getY(), vec.getZ()))
                     .collect(Collectors.toList());
         }
         throw new UnsupportedOperationException();

--- a/compatibility/v7/src/main/java/fr/mrmicky/worldeditselectionvisualizer/compat/v7/utils/Vectors7.java
+++ b/compatibility/v7/src/main/java/fr/mrmicky/worldeditselectionvisualizer/compat/v7/utils/Vectors7.java
@@ -13,21 +13,29 @@ public final class Vectors7 {
 
     @NotNull
     public static Vector3d toVector3d(Vector3 vec) {
+        if (vec == Vector3.ZERO)
+            return Vector3d.ZERO;
         return new Vector3d(vec.getX(), vec.getY(), vec.getZ());
     }
 
     @NotNull
     public static Vector3d toVector3d(BlockVector3 vec) {
+        if (vec == BlockVector3.ZERO)
+            return Vector3d.ZERO;
         return new Vector3d(vec.getX(), vec.getY(), vec.getZ());
     }
 
     @NotNull
     public static Vector3 toVector3(Vector3d vec) {
+        if (vec == Vector3d.ZERO)
+            return Vector3.ZERO;
         return Vector3.at(vec.getX(), vec.getY(), vec.getZ());
     }
 
     @NotNull
     public static BlockVector3 toBlockVector3(Vector3d vec) {
+        if (vec == Vector3d.ZERO)
+            return BlockVector3.ZERO;
         return BlockVector3.at(vec.getX(), vec.getY(), vec.getZ());
     }
 }

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/config/GlobalSelectionConfig.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/config/GlobalSelectionConfig.java
@@ -12,11 +12,14 @@ public class GlobalSelectionConfig {
     @NotNull
     private final SelectionConfig secondary;
 
-    public GlobalSelectionConfig(int fadeDelay, int maxSelectionSize, @NotNull SelectionConfig primary, @NotNull SelectionConfig secondary) {
+    private final PositionBlockConfig positionBlock;
+
+    public GlobalSelectionConfig(int fadeDelay, int maxSelectionSize, @NotNull SelectionConfig primary, @NotNull SelectionConfig secondary, PositionBlockConfig positionBlock) {
         this.fadeDelay = fadeDelay;
         this.maxSelectionSize = maxSelectionSize;
         this.primary = primary;
         this.secondary = secondary;
+        this.positionBlock = positionBlock;
     }
 
     public int getFadeDelay() {
@@ -35,5 +38,9 @@ public class GlobalSelectionConfig {
     @NotNull
     public SelectionConfig secondary() {
         return secondary;
+    }
+
+    public PositionBlockConfig positionBlock() {
+        return positionBlock;
     }
 }

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/config/PositionBlockConfig.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/config/PositionBlockConfig.java
@@ -1,0 +1,28 @@
+package fr.mrmicky.worldeditselectionvisualizer.config;
+
+import org.bukkit.block.data.BlockData;
+
+public class PositionBlockConfig {
+    private final int updateInterval;
+
+    private final BlockData primary;
+    private final BlockData secondary;
+
+    public PositionBlockConfig(int updateInterval, BlockData primary, BlockData secondary) {
+        this.updateInterval = updateInterval;
+        this.primary = primary;
+        this.secondary = secondary;
+    }
+
+    public int getUpdateInterval() {
+        return updateInterval;
+    }
+
+    public BlockData getPrimary() {
+        return primary;
+    }
+
+    public BlockData getSecondary() {
+        return secondary;
+    }
+}

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/config/SelectionConfig.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/config/SelectionConfig.java
@@ -1,6 +1,7 @@
 package fr.mrmicky.worldeditselectionvisualizer.config;
 
 import fr.mrmicky.worldeditselectionvisualizer.display.ParticleData;
+import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/display/ParticlesTask.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/display/ParticlesTask.java
@@ -9,6 +9,8 @@ import fr.mrmicky.worldeditselectionvisualizer.selection.PlayerVisualizerInfos;
 import fr.mrmicky.worldeditselectionvisualizer.selection.SelectionPoints;
 import fr.mrmicky.worldeditselectionvisualizer.selection.SelectionType;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/display/PositionBlockTask.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/display/PositionBlockTask.java
@@ -1,0 +1,107 @@
+package fr.mrmicky.worldeditselectionvisualizer.display;
+
+import fr.mrmicky.worldeditselectionvisualizer.WorldEditSelectionVisualizer;
+import fr.mrmicky.worldeditselectionvisualizer.config.PositionBlockConfig;
+import fr.mrmicky.worldeditselectionvisualizer.math.Vector3d;
+import fr.mrmicky.worldeditselectionvisualizer.selection.PlayerSelection;
+import fr.mrmicky.worldeditselectionvisualizer.selection.PlayerVisualizerInfos;
+import fr.mrmicky.worldeditselectionvisualizer.selection.SelectionPoints;
+import fr.mrmicky.worldeditselectionvisualizer.selection.SelectionType;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.NumberConversions;
+
+import java.util.Objects;
+
+public class PositionBlockTask extends BukkitRunnable {
+    private final WorldEditSelectionVisualizer plugin;
+    private final PositionBlockConfig config;
+
+    public PositionBlockTask(WorldEditSelectionVisualizer plugin, PositionBlockConfig config) {
+        this.plugin = plugin;
+        this.config = config;
+    }
+
+    public BukkitTask start() {
+        if (config == null || config.getPrimary() == null || config.getSecondary() == null)
+            return null;
+        return runTaskTimer(plugin, config.getUpdateInterval(), config.getUpdateInterval());
+    }
+
+    @Override
+    public void run() {
+        boolean needWand = plugin.getConfig().getBoolean("need-we-wand");
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            PlayerVisualizerInfos visualizerInfo = plugin.getPlayerInfos(player);
+
+            PlayerSelection playerSelection = visualizerInfo.getSelection(SelectionType.SELECTION).orElse(null);
+
+            if (playerSelection == null) {
+                clearPositionBlocks(player, visualizerInfo);
+                continue;
+            }
+
+            playerSelection.checkExpireTime();
+            SelectionPoints selectionPoints = playerSelection.getSelectionPoints();
+
+            if (selectionPoints == null || (needWand && !visualizerInfo.isHoldingSelectionItem())) {
+                clearPositionBlocks(player, visualizerInfo);
+                continue;
+            }
+            updatePositionBlocks(player, visualizerInfo, selectionPoints);
+        }
+    }
+
+    private void clearPositionBlocks(Player player, PlayerVisualizerInfos visualizerInfos) {
+        SelectionPoints selectionPoints = visualizerInfos.getSelectionPoints();
+        if (selectionPoints == null)
+            return;
+
+        for (Vector3d pos : selectionPoints.primaryPositions()) {
+            Location location = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+            player.sendBlockChange(location, location.getBlock().getBlockData());
+        }
+        Vector3d pos = selectionPoints.getSecondaryPosition();
+        if (pos != null) {
+            Location location = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+            player.sendBlockChange(location, location.getBlock().getBlockData());
+        }
+
+        visualizerInfos.setSelectionPoints(null);
+    }
+
+    private void updatePositionBlocks(Player player, PlayerVisualizerInfos visualizerInfos, SelectionPoints selectionPoints) {
+        SelectionPoints lastSelectionPoints = visualizerInfos.getSelectionPoints();
+        if (lastSelectionPoints != null) {
+            if (!lastSelectionPoints.primaryPositions().equals(selectionPoints.primaryPositions())) {
+                for (Vector3d pos : visualizerInfos.getSelectionPoints().primaryPositions()) {
+                    Location location = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+                    player.sendBlockChange(location, location.getBlock().getBlockData());
+                }
+            }
+            if (!Objects.equals(lastSelectionPoints.getSecondaryPosition(), selectionPoints.getSecondaryPosition())) {
+                Vector3d pos = lastSelectionPoints.getSecondaryPosition();
+                if (pos != null) {
+                    Location location = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+                    player.sendBlockChange(location, location.getBlock().getBlockData());
+                }
+            }
+        }
+
+        for (Vector3d pos : selectionPoints.primaryPositions()) {
+            Location location = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+            player.sendBlockChange(location, config.getPrimary());
+        }
+        Vector3d pos = selectionPoints.getSecondaryPosition();
+        if (pos != null) {
+            Location location = new Location(player.getWorld(), pos.getX(), pos.getY(), pos.getZ());
+            player.sendBlockChange(location, config.getSecondary());
+        }
+
+        visualizerInfos.setSelectionPoints(selectionPoints);
+    }
+}

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/PlayerVisualizerInfos.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/PlayerVisualizerInfos.java
@@ -1,5 +1,6 @@
 package fr.mrmicky.worldeditselectionvisualizer.selection;
 
+import fr.mrmicky.worldeditselectionvisualizer.math.Vector3d;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,6 +22,8 @@ public class PlayerVisualizerInfos {
     private final Map<SelectionType, PlayerSelection> enabledVisualizations = new EnumMap<>(SelectionType.class);
 
     private boolean holdingSelectionItem = true;
+
+    private SelectionPoints selectionPoints = null;
 
     public PlayerVisualizerInfos(@NotNull Player player) {
         this.player = Objects.requireNonNull(player, "player");
@@ -51,6 +54,14 @@ public class PlayerVisualizerInfos {
 
     public boolean isSelectionVisible(SelectionType type) {
         return enabledVisualizations.containsKey(type);
+    }
+
+    public void setSelectionPoints(SelectionPoints selectionPoints) {
+        this.selectionPoints = selectionPoints;
+    }
+
+    public SelectionPoints getSelectionPoints() {
+        return selectionPoints;
     }
 
     public void toggleSelectionVisibility(SelectionType type, boolean enable) {

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/SelectionPoints.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/SelectionPoints.java
@@ -1,5 +1,6 @@
 package fr.mrmicky.worldeditselectionvisualizer.selection;
 
+import com.sk89q.worldedit.math.BlockVector3;
 import fr.mrmicky.worldeditselectionvisualizer.math.Vector3d;
 import org.jetbrains.annotations.NotNull;
 
@@ -7,6 +8,8 @@ import java.util.Collection;
 import java.util.HashSet;
 
 public class SelectionPoints {
+    private final Collection<Vector3d> primaryPositions = new HashSet<>();
+    private Vector3d secondaryPosition = null;
 
     private final Collection<Vector3d> primaryPoints = new HashSet<>();
     private final Collection<Vector3d> secondaryPoints = new HashSet<>();
@@ -32,4 +35,13 @@ public class SelectionPoints {
     public Vector3d origin() {
         return origin;
     }
+
+    @NotNull
+    public Collection<Vector3d> primaryPositions() { return primaryPositions; }
+
+    public void setSecondaryPosition(Vector3d secondaryPosition) {
+        this.secondaryPosition = secondaryPosition;
+    }
+
+    public Vector3d getSecondaryPosition() { return secondaryPosition; }
 }

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/WorldEditHelper.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/WorldEditHelper.java
@@ -5,6 +5,7 @@ import com.sk89q.worldedit.IncompleteRegionException;
 import com.sk89q.worldedit.LocalSession;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.transform.Transform;
 import com.sk89q.worldedit.regions.ConvexPolyhedralRegion;
 import com.sk89q.worldedit.regions.CuboidRegion;
@@ -13,6 +14,7 @@ import com.sk89q.worldedit.regions.EllipsoidRegion;
 import com.sk89q.worldedit.regions.Polygonal2DRegion;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.RegionSelector;
+import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import fr.mrmicky.worldeditselectionvisualizer.WorldEditSelectionVisualizer;
 import fr.mrmicky.worldeditselectionvisualizer.compat.RegionAdapter;
@@ -27,11 +29,15 @@ import fr.mrmicky.worldeditselectionvisualizer.selection.shape.type.EllipsoidPro
 import fr.mrmicky.worldeditselectionvisualizer.selection.shape.type.FawePolyhedralProcessor;
 import fr.mrmicky.worldeditselectionvisualizer.selection.shape.type.Polygonal2DProcessor;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class WorldEditHelper extends BukkitRunnable {
@@ -134,17 +140,19 @@ public class WorldEditHelper extends BukkitRunnable {
         }
 
         GlobalSelectionConfig config = plugin.getSelectionConfig(type);
-        int area = region.getArea();
+        if (session.isSelectionDefined(session.getSelectionWorld())) {
+            int area = region.getArea();
 
-        if (area < 0 || area > config.getMaxSelectionSize()) {
-            if (!playerSelection.isLastSelectionTooLarge()) {
-                String message = plugin.getMessage("selection-too-large").replace("%blocks%", Integer.toString(config.getMaxSelectionSize()));
-                plugin.getCompatibilityHelper().sendActionBar(player, message);
+            if (area < 0 || area > config.getMaxSelectionSize()) {
+                if (!playerSelection.isLastSelectionTooLarge()) {
+                    String message = plugin.getMessage("selection-too-large").replace("%blocks%", Integer.toString(config.getMaxSelectionSize()));
+                    plugin.getCompatibilityHelper().sendActionBar(player, message);
+                }
+
+                playerSelection.resetSelection(regionInfos);
+                playerSelection.setLastSelectionTooLarge(true);
+                return;
             }
-
-            playerSelection.resetSelection(regionInfos);
-            playerSelection.setLastSelectionTooLarge(true);
-            return;
         }
 
         plugin.updateHoldingSelectionItem(playerInfo);
@@ -166,13 +174,13 @@ public class WorldEditHelper extends BukkitRunnable {
         if (session != null && session.getSelectionWorld() != null) {
             RegionSelector selector = session.getRegionSelector(session.getSelectionWorld());
 
-            if (selector.isDefined()) {
+            //if (selector.isDefined()) {
                 try {
-                    return selector.getRegion();
+                    return selector.getIncompleteRegion();
                 } catch (IncompleteRegionException e) {
                     plugin.getLogger().warning("Region still incomplete");
                 }
-            }
+            //}
         }
         return null;
     }

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/ShapeProcessor.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/ShapeProcessor.java
@@ -6,6 +6,7 @@ import fr.mrmicky.worldeditselectionvisualizer.compat.RegionAdapter;
 import fr.mrmicky.worldeditselectionvisualizer.config.GlobalSelectionConfig;
 import fr.mrmicky.worldeditselectionvisualizer.math.Vector3d;
 import fr.mrmicky.worldeditselectionvisualizer.selection.SelectionPoints;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/type/ConvexPolyhedralProcessor.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/type/ConvexPolyhedralProcessor.java
@@ -4,7 +4,11 @@ import com.sk89q.worldedit.regions.ConvexPolyhedralRegion;
 import fr.mrmicky.worldeditselectionvisualizer.WorldEditSelectionVisualizer;
 import fr.mrmicky.worldeditselectionvisualizer.compat.RegionAdapter;
 import fr.mrmicky.worldeditselectionvisualizer.config.GlobalSelectionConfig;
+import fr.mrmicky.worldeditselectionvisualizer.math.Vector3d;
 import fr.mrmicky.worldeditselectionvisualizer.selection.SelectionPoints;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public class ConvexPolyhedralProcessor extends AbstractConvexProcessor<ConvexPolyhedralRegion> {
 
@@ -14,6 +18,7 @@ public class ConvexPolyhedralProcessor extends AbstractConvexProcessor<ConvexPol
 
     @Override
     protected void processSelection(SelectionPoints selection, ConvexPolyhedralRegion region, RegionAdapter regionAdapter, GlobalSelectionConfig config) {
+        selection.primaryPositions().addAll(regionAdapter.getPolyhedralVertices());
         createTriangles(selection.primary(), regionAdapter.getConvexTriangles(), config.primary().getPointsDistance());
     }
 }

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/type/CuboidProcessor.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/type/CuboidProcessor.java
@@ -1,5 +1,6 @@
 package fr.mrmicky.worldeditselectionvisualizer.selection.shape.type;
 
+import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import fr.mrmicky.worldeditselectionvisualizer.WorldEditSelectionVisualizer;
 import fr.mrmicky.worldeditselectionvisualizer.compat.RegionAdapter;
@@ -7,6 +8,7 @@ import fr.mrmicky.worldeditselectionvisualizer.config.GlobalSelectionConfig;
 import fr.mrmicky.worldeditselectionvisualizer.math.Vector3d;
 import fr.mrmicky.worldeditselectionvisualizer.selection.SelectionPoints;
 import fr.mrmicky.worldeditselectionvisualizer.selection.shape.ShapeProcessor;
+import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +21,16 @@ public class CuboidProcessor extends ShapeProcessor<CuboidRegion> {
 
     @Override
     public void processSelection(SelectionPoints selection, CuboidRegion region, RegionAdapter regionAdapter, GlobalSelectionConfig config) {
+        Vector3d pos1 = regionAdapter.getPos1();
+        Vector3d pos2 = regionAdapter.getPos2();
+        if (pos1 != Vector3d.ZERO)
+            selection.primaryPositions().add(pos1);
+        if (pos2 != Vector3d.ZERO)
+            selection.setSecondaryPosition(pos2);
+        if (pos1 == Vector3d.ZERO || pos2 == Vector3d.ZERO)
+            // incomplete selection, can't draw lines.
+            return;
+
         Vector3d min = regionAdapter.getMinimumPoint();
         Vector3d max = regionAdapter.getMaximumPoint().add(1, 1, 1);
         int height = region.getHeight();

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/type/CylinderProcessor.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/type/CylinderProcessor.java
@@ -1,5 +1,6 @@
 package fr.mrmicky.worldeditselectionvisualizer.selection.shape.type;
 
+import com.sk89q.worldedit.math.Vector2;
 import com.sk89q.worldedit.regions.CylinderRegion;
 import fr.mrmicky.worldeditselectionvisualizer.WorldEditSelectionVisualizer;
 import fr.mrmicky.worldeditselectionvisualizer.compat.RegionAdapter;
@@ -18,6 +19,13 @@ public class CylinderProcessor extends ShapeProcessor<CylinderRegion> {
 
     @Override
     protected void processSelection(SelectionPoints selection, CylinderRegion region, RegionAdapter regionAdapter, GlobalSelectionConfig config) {
+        if (regionAdapter.getCenter() == Vector3d.ZERO)
+            return;
+        selection.primaryPositions().add(regionAdapter.getCenter());
+        if (region.getRadius().equals(Vector2.ZERO))
+            // Selection is incomplete. Can't add lines.
+            return;
+
         Vector3d min = regionAdapter.getMinimumPoint();
         Vector3d max = regionAdapter.getMaximumPoint().add(1, 1, 1);
         Vector3d bottomCenter = regionAdapter.getCenter().withY(min.getY()).add(0.5, 0.0, 0.5);

--- a/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/type/EllipsoidProcessor.java
+++ b/plugin/src/main/java/fr/mrmicky/worldeditselectionvisualizer/selection/shape/type/EllipsoidProcessor.java
@@ -1,5 +1,6 @@
 package fr.mrmicky.worldeditselectionvisualizer.selection.shape.type;
 
+import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.regions.EllipsoidRegion;
 import fr.mrmicky.worldeditselectionvisualizer.WorldEditSelectionVisualizer;
 import fr.mrmicky.worldeditselectionvisualizer.compat.RegionAdapter;
@@ -16,8 +17,16 @@ public class EllipsoidProcessor extends ShapeProcessor<EllipsoidRegion> {
 
     @Override
     protected void processSelection(SelectionPoints selection, EllipsoidRegion region, RegionAdapter regionAdapter, GlobalSelectionConfig config) {
+        Vector3d center = regionAdapter.getCenter();
+        if (center == Vector3d.ZERO)
+            return;
+        selection.primaryPositions().add(new Vector3d(center.getX(), center.getY(), center.getZ()));
+        if (region.getRadius().lengthSq() == 0)
+            // Selection is incomplete.
+            return;
+
         Vector3d radius = regionAdapter.getEllipsoidRadius().add(0.5, 0.5, 0.5);
-        Vector3d center = regionAdapter.getCenter().add(0.5, 0.5, 0.5);
+        center = regionAdapter.getCenter().add(0.5, 0.5, 0.5);
 
         selection.primary().add(center);
 

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -45,6 +45,12 @@ visualization:
   selection:
     fade-delay: 0
     max-selection-size: 50000
+    position-block:
+      view-distance: 64
+      primary:
+        material: DIAMOND_BLOCK
+      secondary:
+        material: GOLD_BLOCK
     primary:
       points-distance: 0.5
       update-interval: 10


### PR DESCRIPTION
Took a shot at implementing #34, and this is the result. Unfortunately I don't think this is a good solution. I wanted to change as little of the existing plugin as possible, but had to implement several changes I consider somewhat dirty. I think to implement this cleanly, the plugin would need significant restructuring.

All in all, I think that without restructuring, this functionality might be better suited as an independent plugin. But since the implementation is functional, I at least wanted to throw it out there. At the very least, if you decide that restructuring is needed, but you still would like to implement the functionality, you're welcome to use the code.

Demos:
* Cuboid: https://stormcloud9-misc.s3.amazonaws.com/wesv-cuboid.webm
* Polygon: Unaffected. Functionality doesn't apply well to this shape type.
* Ellipsoid: https://stormcloud9-misc.s3.amazonaws.com/wesv-ellipsoid.webm
* Sphere: https://stormcloud9-misc.s3.amazonaws.com/wesv-sphere.webm
* Cylinder: https://stormcloud9-misc.s3.amazonaws.com/wesv-cyl.webm
* Polyhedron: https://stormcloud9-misc.s3.amazonaws.com/wesv-convex.webm
* Toggling: https://stormcloud9-misc.s3.amazonaws.com/wesv-toggle.webm

 
